### PR TITLE
Main klaudiam skalowanie wydruku

### DIFF
--- a/QuickPrint.py
+++ b/QuickPrint.py
@@ -65,6 +65,13 @@ class PrintMapTool:
         # 'A9': (37, 52),
         # 'A10': (26, 37),
     }
+    dict_width = {148: 50,
+                  210: 90,
+                  297: 145,
+                  420: 220,
+                  594: 335,
+                  841: 475,
+                  1189: 700}
 
     def __init__(self, iface : QgisInterface, parent : QtWidgets=None) -> None:
         self.iface = iface
@@ -98,9 +105,14 @@ class PrintMapTool:
         width, height = self.mm_paper_sizes[paper_format]
 
         if self.dialog.horizontalRadioButton.isChecked():
+            self.set_adnotation_limit(height)
             return height, width
-        else:
+        if self.dialog.verticalRadioButton.isChecked():
+            self.set_adnotation_limit(width)
             return width, height
+
+    def set_adnotation_limit(self, width: int) -> None:
+        self.dialog.adnotacje_lineEdit.setMaxLength(self.dict_width[width])
 
     def get_map_item(self) -> QgsLayoutItemMap:
         item_object = None
@@ -121,7 +133,8 @@ class PrintMapTool:
             pos_x, pos_y = 16, 16
             page.setPageSize(QgsLayoutSize(width, height))
             canvas_extent = self.iface.mapCanvas().extent()
-            current_rect = QRectF(pos_x, pos_y, width, height)
+            current_rect = QRectF(pos_x, pos_y, width - 2 * pos_x, height - 2 * pos_y)
+
             map_item = QgsLayoutItemMap(self.layout)
             map_item.updateBoundingRect()
             map_item.setRect(current_rect)
@@ -139,17 +152,6 @@ class PrintMapTool:
 
             self.layout.addItem(map_item)
 
-            self.iface.mapCanvas().scaleChanged.disconnect(
-                self.create_composer)
-            self.iface.mapCanvas().setScaleLocked(True)
-            xmin = (map_item.extent().xMinimum()) - pos_x
-            xmax = (map_item.extent().xMaximum()) + pos_x
-            ymin = (map_item.extent().yMinimum()) - pos_x
-            ymax = (map_item.extent().yMaximum()) + pos_x
-            self.iface.mapCanvas().setExtent(QgsRectangle(xmin, ymin, xmax, ymax), magnified=True)
-            self.iface.mapCanvas().scaleChanged.connect(
-                self.create_composer)
-            self.iface.mapCanvas().setScaleLocked(False)
 
     def reset_rubber(self) -> None:
         self.rubberband.reset(QgsWkbTypes.PolygonGeometry)
@@ -325,127 +327,7 @@ class PrintMapTool:
         if self.dialog.adnotacje_lineEdit.text():
             adnotation = QgsLayoutItemLabel(self.layout)
             adnotation_font = QFont()
-            default_font_Size = 10
-            if width == 148 and len(self.dialog.adnotacje_lineEdit.text()) > 50:
-                if 50 <= len(self.dialog.adnotacje_lineEdit.text()) <= 55:
-                    default_font_Size = 7
-                if 55 < len(self.dialog.adnotacje_lineEdit.text()) <= 65:
-                    default_font_Size = 6
-                if 65 < len(self.dialog.adnotacje_lineEdit.text()) <= 76:
-                    default_font_Size = 5
-                if 76 < len(self.dialog.adnotacje_lineEdit.text()) <= 96:
-                    default_font_Size = 4
-                if len(self.dialog.adnotacje_lineEdit.text()) > 96:
-                    default_font_Size = 3
-                if len(self.dialog.adnotacje_lineEdit.text()) > 128:
-                    return
-                else:
-                    adnotation.setText(self.dialog.adnotacje_lineEdit.text())
-
-            elif width == 210 and len(self.dialog.adnotacje_lineEdit.text()) > 90:
-                if 90 <= len(self.dialog.adnotacje_lineEdit.text()) <= 98:
-                    default_font_Size = 7
-                if 98 < len(self.dialog.adnotacje_lineEdit.text()) <= 118:
-                    default_font_Size = 6
-                if 118 < len(self.dialog.adnotacje_lineEdit.text()) <= 140:
-                    default_font_Size = 5
-                if 140 < len(self.dialog.adnotacje_lineEdit.text()) <= 175:
-                    default_font_Size = 4
-                if len(self.dialog.adnotacje_lineEdit.text()) > 175:
-                    default_font_Size = 3
-                if len(self.dialog.adnotacje_lineEdit.text()) > 225:
-                    return
-                else:
-                    adnotation.setText(self.dialog.adnotacje_lineEdit.text())
-
-            elif width == 297 and len(self.dialog.adnotacje_lineEdit.text()) > 145:
-                if 145 <= len(self.dialog.adnotacje_lineEdit.text()) <= 160:
-                    default_font_Size = 7
-                if 160 < len(self.dialog.adnotacje_lineEdit.text()) <= 190:
-                    default_font_Size = 6
-                if 190 < len(self.dialog.adnotacje_lineEdit.text()) <= 225:
-                    default_font_Size = 5
-                if 225 < len(self.dialog.adnotacje_lineEdit.text()) <= 270:
-                    default_font_Size = 4
-                if len(self.dialog.adnotacje_lineEdit.text()) > 270:
-                    default_font_Size = 3
-                if len(self.dialog.adnotacje_lineEdit.text()) > 368:
-                    return
-                else:
-                    adnotation.setText(self.dialog.adnotacje_lineEdit.text())
-
-            elif width == 420 and len(self.dialog.adnotacje_lineEdit.text()) > 220:
-                if 220 <= len(self.dialog.adnotacje_lineEdit.text()) <= 245:
-                    default_font_Size = 7
-                if 245 < len(self.dialog.adnotacje_lineEdit.text()) <= 280:
-                    default_font_Size = 6
-                if 280 < len(self.dialog.adnotacje_lineEdit.text()) <= 345:
-                    default_font_Size = 5
-                if 345 < len(self.dialog.adnotacje_lineEdit.text()) <= 425:
-                    default_font_Size = 4
-                if len(self.dialog.adnotacje_lineEdit.text()) > 425:
-                    default_font_Size = 3
-                if len(self.dialog.adnotacje_lineEdit.text()) > 555:
-                    return
-                else:
-                    adnotation.setText(self.dialog.adnotacje_lineEdit.text())
-
-            elif width == 594 and len(self.dialog.adnotacje_lineEdit.text()) > 335:
-                if 335 <= len(self.dialog.adnotacje_lineEdit.text()) <= 360:
-                    default_font_Size = 7
-                if 360 < len(self.dialog.adnotacje_lineEdit.text()) <= 440:
-                    default_font_Size = 6
-                if 440 < len(self.dialog.adnotacje_lineEdit.text()) <= 510:
-                    default_font_Size = 5
-                if 510 < len(self.dialog.adnotacje_lineEdit.text()) <= 640:
-                    default_font_Size = 4
-                if len(self.dialog.adnotacje_lineEdit.text()) > 640:
-                    default_font_Size = 3
-                if len(self.dialog.adnotacje_lineEdit.text()) > 850:
-                    return
-                else:
-                    adnotation.setText(self.dialog.adnotacje_lineEdit.text())
-
-            elif width == 841 and len(self.dialog.adnotacje_lineEdit.text()) > 475:
-                if 475 <= len(self.dialog.adnotacje_lineEdit.text()) <= 540:
-                    default_font_Size = 7
-                if 540 < len(self.dialog.adnotacje_lineEdit.text()) <= 640:
-                    default_font_Size = 6
-                if 640 < len(self.dialog.adnotacje_lineEdit.text()) <= 760:
-                    default_font_Size = 5
-                if 760 < len(self.dialog.adnotacje_lineEdit.text()) <= 960:
-                    default_font_Size = 4
-                if len(self.dialog.adnotacje_lineEdit.text()) > 960:
-                    default_font_Size = 3
-                if len(self.dialog.adnotacje_lineEdit.text()) > 1250:
-                    return
-                else:
-                    adnotation.setText(self.dialog.adnotacje_lineEdit.text())
-
-            elif width == 1189 and len(
-                    self.dialog.adnotacje_lineEdit.text()) > 700:
-                if 700 < len(self.dialog.adnotacje_lineEdit.text()) <= 780:
-                    default_font_Size = 7
-                if 780 < len(self.dialog.adnotacje_lineEdit.text()) <= 940:
-                    default_font_Size = 6
-                if 940 < len(self.dialog.adnotacje_lineEdit.text()) <= 1090:
-                    default_font_Size = 5
-                if 1090 < len(self.dialog.adnotacje_lineEdit.text()) <= 1320:
-                    default_font_Size = 4
-                if len(self.dialog.adnotacje_lineEdit.text()) > 1320:
-                    default_font_Size = 3
-                if len(self.dialog.adnotacje_lineEdit.text()) > 1250:
-                    # CustomMessageBox(self.dialog, 'Adnotacja zawiera za dużo znaków').button_ok()
-                    return
-                else:
-                    adnotation.setText(
-                        self.dialog.adnotacje_lineEdit.text() + '\n' + self.dialog.adnotacje_lineEdit.text())
-            else:
-                adnotation.setText(
-                    self.dialog.adnotacje_lineEdit.text() + '\n' + self.dialog.adnotacje_lineEdit.text())
-            adnotation.setText(
-                self.dialog.adnotacje_lineEdit.text() + '\n' + self.dialog.adnotacje_lineEdit.text())
-            adnotation_font.setPointSize(int(default_font_Size))
+            adnotation.setText(self.dialog.adnotacje_lineEdit.text())
             adnotation.setFont(adnotation_font)
             adnotation.adjustSizeToText()
             self.layout.addItem(adnotation)

--- a/Settings/ui_settings_layout.ui
+++ b/Settings/ui_settings_layout.ui
@@ -389,6 +389,64 @@ p, li { white-space: pre-wrap; }
            </widget>
           </item>
           <item>
+           <widget class="QGroupBox" name="groupBox_5">
+            <property name="title">
+             <string>Choose font size</string>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_2">
+             <property name="topMargin">
+              <number>20</number>
+             </property>
+              <property name="leftMargin">
+               <number>9</number>
+              </property>
+              <property name="topMargin">
+               <number>20</number>
+              </property>
+              <property name="rightMargin">
+               <number>600</number>
+              </property>
+              <property name="bottomMargin">
+               <number>9</number>
+              </property>
+              <item row="0" column="0">
+               <widget class="QSpinBox" name="spinBox_font">
+                <property name="minimum">
+                <number>5</number>
+                </property>
+                <property name="maximum">
+                <number>30</number>
+                </property>
+<!--                <property name="value">-->
+<!--                <number>10</number>-->
+<!--                </property>-->
+               </widget>
+              </item>
+             <item row="0" column="1">
+              <widget class="QPushButton" name="spinBox_button">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>200</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="text">
+                <string>Choose font size</string>
+               </property>
+              </widget>
+             </item>
+
+
+            </layout>
+           </widget>
+          </item>
+          <item>
            <spacer name="verticalSpacer">
             <property name="orientation">
              <enum>Qt::Vertical</enum>

--- a/config.py
+++ b/config.py
@@ -20,6 +20,7 @@ class Config:
                 conf = fl.read()
             try:
                 self.setts = json.loads(conf)[0]
+                self.setts['value'] = 20
             except ValueError:
                 QgsMessageLog.logMessage(
                     'Failed to load config from config.json')

--- a/giap_dynamic_layout.py
+++ b/giap_dynamic_layout.py
@@ -1120,7 +1120,7 @@ class CustomLabel(QLabel):
         self.setAttribute(Qt.WA_DeleteOnClose)
         self.setText(lab)
         self.setStyleSheet(
-            'font: 10pt "Segoe UI"; font-weight: normal; '
+            'font: "Segoe UI"; font-weight: normal; '
         )
         self.cinput = QLineEdit(self)
         self.cinput.setWindowFlags(Qt.Popup)

--- a/giap_dynamic_layout.ui
+++ b/giap_dynamic_layout.ui
@@ -95,12 +95,14 @@
         </size>
        </property>
        <property name="styleSheet">
-        <string notr="true">QToolButton
-{
-    font: 8pt &quot;Segoe UI&quot;;
-	font-weight: bold;
-    border: none;
-}</string>
+        <string notr="true">
+<!--QToolButton&ndash;&gt;-->
+<!--{-->
+<!--    font: 8pt &quot;Segoe UI&quot;;-->
+<!--	font-weight: bold;-->
+<!--    border: none};-->
+
+</string>
        </property>
        <property name="text">
         <string>Layers</string>

--- a/giap_layout.py
+++ b/giap_layout.py
@@ -12,7 +12,7 @@ from qgis.PyQt.QtWidgets import QAction, QToolBar, QToolButton, QWidget, \
     QHBoxLayout, QMenu, QMessageBox
 from qgis.PyQt.QtWidgets import QDockWidget, QVBoxLayout
 from qgis.PyQt.QtWidgets import QPushButton
-from qgis.core import QgsProject, Qgis, QgsSettings, QgsApplication
+from qgis._core import QgsProject, Qgis, QgsSettings
 from qgis.utils import iface
 
 from .Kompozycje.Kompozycje import CompositionsTool
@@ -30,6 +30,7 @@ from .utils import tr, Qt, icon_manager, CustomMessageBox
 from .AreaAndLengthTool.AreaAndLengthTool import AreaAndLengthTool
 from qgis.gui import QgsMapTool
 project = QgsProject.instance()
+from . import giap_dynamic_layout
 
 
 class MainTabQgsWidget:
@@ -47,6 +48,9 @@ class MainTabQgsWidget:
         self.plugin_dir = os.path.dirname(__file__)
         self.install_translator()
         self.main_widget = MainWidget(self.iface.mainWindow())
+        self.status_bar = MainWidget(self.iface.statusBarIface())
+        self.tab_bar = MainWidget().tabWidget
+        self.tab_bar.setWindowTitle('afdfsdfs')
         self.kompozycje_widget = kompozycjeWidget()
         self.left_docks = []
         self.config = Config()
@@ -467,6 +471,7 @@ class MainTabQgsWidget:
             self.set_dlg.radioButton_en.setChecked(True)
         elif str(QSettings().value('locale/userLocale')) == "pl_PL":
             self.set_dlg.radioButton_pl.setChecked(True)
+        self.set_dlg.spinBox_button.clicked.connect(self.set_size)
         self.set_dlg.exec_()
 
     def set_polish(self) -> None:
@@ -500,6 +505,19 @@ class MainTabQgsWidget:
             0
         )
         self.restart_qgis()
+
+    def set_size(self):
+        self.set_dlg.spinBox_font.setValue(self.set_dlg.spinBox_font.value())
+        value = self.set_dlg.spinBox_font.value()
+        # self.style_manager.run_last_style()
+        get_qgis_app()
+
+        self.kompozycje_widget.setStyleSheet(f'font: {value}pt;')  # napis kompoyzje wszystkie warstwy
+        # raise NotImplementedError
+        # custom_label = giap_dynamic_layout.CustomLabel(tr('New section'))
+        # custom_label.setStyleSheet(f'font: {value}pt;')
+        self.style_manager.run_last_style(value)
+
 
     def restore_default_ribbon_settings(self) -> None:
         self.set_dlg.pushButton_restore.clicked.disconnect()

--- a/kompozycje_widget.ui
+++ b/kompozycje_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>160</width>
-    <height>57</height>
+    <width>699</width>
+    <height>141</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/styles/GIAP Navy Blue/giap.qss
+++ b/styles/GIAP Navy Blue/giap.qss
@@ -13,7 +13,7 @@ QWidget
 	background-color:  rgb(53, 85, 109);
 	selection-background-color: #6FB1E3;
 	selection-color:  #EDF6FC;
-    font: 10pt "Segoe UI";
+    font: 20pt "Segoe UI";
 }
 
 QMenuBar
@@ -81,7 +81,7 @@ QAbstractItemView
 	alternate-background-color:  #4f5a63;
 	color:  #EDF6FC;
 	border-radius: 3px;
-	font: 9pt "Segoe UI";
+	font: 9pt "Segoe UI"; /* ortofotomapa */
 	background-color: #6FB1E3;
 }
 
@@ -186,7 +186,7 @@ QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {
 
 QTabBar {
     qproperty-drawBase: 0;
-    font: 10pt "Segoe UI";
+    font: 10pt "Segoe UI"; /* komunikaty wtyczki general */
 	font-weight: 600;
 }
 
@@ -283,7 +283,7 @@ QComboBox
 	border-style: solid;
 	border-radius: 3px;
 	padding: 2px;
-	font: 10pt "Segoe UI";
+	font: 20pt "Segoe UI";
     height: 20px;
 }
 
@@ -716,7 +716,7 @@ QProgressBar::chunk:horizontal {
 
 QToolBar QLabel
 {
-    font: 9pt "Segoe UI";
+    font: 9pt "Segoe UI"; #na gorze projekt nawigacja atrybuty
 	font-weight: bold;
 	border: none;
 }

--- a/tests/qgis_interface.py
+++ b/tests/qgis_interface.py
@@ -188,6 +188,9 @@ class QgisInterface(QObject):
         In case of QGIS it returns an instance of QgisApp.
         """
         pass
+    #
+    # def statusBarIface(self):
+    #     pass
 
     def addDockWidget(self, area, dock_widget):
         """Add a dock widget to the main window.


### PR DESCRIPTION
Task #18073.
-ramka widoczna przy wybraniu szybkiego wydruku jest mniejsza, niż całkowity widok w qgisie;
-ograniczono maksymalną ilość znaków dla adnotacji w zależności od orientacji i formatu papieru.