### PR TITLE
Task #16513. Dopasowanie interfejsu pod skalowanie

### DIFF
--- a/Kompozycje/Kompozycje.py
+++ b/Kompozycje/Kompozycje.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from time import sleep
 
 from qgis.PyQt import QtCore
-from qgis.PyQt.QtCore import QObject, pyqtSignal, QItemSelectionModel
+from qgis.PyQt.QtCore import QObject, pyqtSignal, QItemSelectionModel, QSettings
 from qgis.PyQt.QtGui import QStandardItemModel, QStandardItem
 from qgis.PyQt.QtWidgets import QMessageBox, QApplication, QItemDelegate, \
     QCheckBox, QFileDialog, QProgressDialog, QToolButton, QGraphicsBlurEffect
@@ -29,6 +29,7 @@ from ..utils import get_project_config, SingletonModel, \
     set_project_config, identify_layer_by_id, ConfigSaveProgressDialog, \
     icon_manager
 from ..utils import tr, CustomMessageBox, Qt
+from ..config import Config
 
 LayersPanel = lsp
 
@@ -103,6 +104,12 @@ def get_user_compositions_gui():
             CustomMessageBox(None, tr('Failed to load settings.')).button_ok()
         progress.stop()
     return user_comp
+
+def config():
+    return Config()
+
+def font_size():
+    return QSettings().value("qgis/stylesheet/fontPointSize")
 
 
 class CompositionsTool(object):
@@ -205,6 +212,8 @@ class CompositionsConfig(QObject):
         self.dlg.komp_dol.clicked.connect(self.move_comp_down)
         self.dlg.komp_gora.clicked.connect(self.move_comp_up)
         self.model_kompozycji.rowsInserted.connect(self.comps_order_change)
+        if config().setts['font_changed']:
+            self.set_font_dodajkompozycje(font_size())
 
         self.check_for_changes_in_comps()
         self.create_table_model()
@@ -213,6 +222,16 @@ class CompositionsConfig(QObject):
             dialog = self.dlg.exec_()
             if dialog:
                 self.save()
+
+    def set_font_dodajkompozycje(self, font_size):
+        self.dlg.pushButton_2.setStyleSheet(
+            f'{self.dlg.pushButton_2.styleSheet()} QPushButton{{font: {font_size}pt;}}')
+        self.dlg.wczytaj.setStyleSheet(f'{self.dlg.wczytaj.styleSheet()} font: {font_size}pt;')
+        self.dlg.zapisz.setStyleSheet(f'{self.dlg.zapisz.styleSheet()} QPushButton {{font: {font_size}pt;}}')
+        self.dlg.frame_23.setStyleSheet(
+            f'{self.dlg.frame_23.styleSheet()} QPushButton, QLabel, QTableView {{font: {font_size}pt;}}')
+        self.dlg.frame_24.setStyleSheet(f'{self.dlg.frame_24.styleSheet()} font: {font_size}pt;')
+
 
     def write_file(self):
         blur = QGraphicsBlurEffect()
@@ -487,10 +506,20 @@ class CompositionsSaver(object):
         self.dlg.tabela.setModel(self.model)
         self.dlg.tabela.horizontalHeader().hide()
         self.dlg.tabela.verticalHeader().hide()
+        if config().setts['font_changed']:
+            self.set_font_compositionsaver(font_size())
 
         result = self.dlg.exec_()
         if result:
             self.write()
+
+    def set_font_compositionsaver(self, font_size):
+        self.dlg.label_2.setStyleSheet(f'{self.dlg.label_2.styleSheet()} font: {font_size}pt;')
+        self.dlg.pushButton_3.setStyleSheet(f'font: {font_size}pt;')
+        self.dlg.groupBox_11.setStyleSheet(
+            f'{self.dlg.groupBox_11.styleSheet()} QPushButton {{font: {font_size}pt;}}')
+        self.dlg.title_label_12.setStyleSheet(f'{self.dlg.title_label_12.styleSheet()} font: {font_size}pt;')
+        self.dlg.frame_2.setStyleSheet(f'{self.dlg.frame_2.styleSheet()} font: {font_size}pt;')
 
 
 class CompositionsAdder(object):
@@ -520,9 +549,21 @@ class CompositionsAdder(object):
         self.dlg.wdol_warstwe.hide()
         self.dlg.wgore_warstwe.hide()
         self.wczytaj_grupy()
+        if config().setts['font_changed']:
+            self.set_font_nowakompozycja(font_size())
         if not self.dlg.isActiveWindow():
             self.dlg.show()
             self.dlg.exec_()
+
+    def set_font_nowakompozycja(self, font_size):
+        self.dlg.frame.setStyleSheet(
+            f'{self.dlg.frame.styleSheet()} QFrame, QLabel, QWidget {{font: {font_size}pt;}}')
+        self.dlg.frame_2.setStyleSheet(f'{self.dlg.frame_2.styleSheet()} font: {font_size}pt;')
+        self.dlg.frame_3.setStyleSheet(f'{self.dlg.frame_3.styleSheet()} font: {font_size}pt;')
+        self.dlg.frame_4.setStyleSheet(f'{self.dlg.frame_4.styleSheet()} font: {font_size}pt;')
+        self.dlg.pushButton.setStyleSheet(f'{self.dlg.pushButton.styleSheet()} font: {font_size}pt;')
+        self.dlg.pushButton_2.setStyleSheet(f'{self.dlg.pushButton_2.styleSheet()} font: {font_size}pt;')
+        self.dlg.label_3.setStyleSheet(f'{self.dlg.label_3.styleSheet()} font: {font_size}pt;')
 
     def save(self):
         comp_name = self.dlg.nazwa_lineEdit.text()

--- a/Kompozycje/nowa_kompozycja.py
+++ b/Kompozycje/nowa_kompozycja.py
@@ -4,7 +4,11 @@ import os
 
 from qgis.PyQt import QtWidgets, uic, QtCore, QtGui
 
+from qgis.PyQt.QtCore import QSettings
+
 from ..utils import tr, CustomMessageBox
+
+from ..config import Config
 
 FORM_CLASS, _ = uic.loadUiType(os.path.join(
     os.path.dirname(__file__), 'nowa_kompozycja.ui'))
@@ -24,6 +28,9 @@ class NowaKompozycjaDialog(QtWidgets.QDialog, FORM_CLASS):
         self.uncheckPushButton.clicked.connect(self.uncheck)
         self.checkAllPushButton.clicked.connect(self.check_all)
         self.uncheckAllPushButton.clicked.connect(self.uncheck_all)
+        if Config().setts['font_changed']:
+            CustomMessageBox.stylesheet += \
+                f'\n* {{font: {QSettings().value("qgis/stylesheet/fontPointSize")}pt}}'
 
     def check(self):
         try:

--- a/OrtoTools.py
+++ b/OrtoTools.py
@@ -2,11 +2,12 @@
 
 from __future__ import absolute_import
 
-from qgis.PyQt.QtCore import QObject, pyqtSignal
+from qgis.PyQt.QtCore import QObject, pyqtSignal, QSettings
 from qgis.PyQt.QtWidgets import QToolButton, QMenu, QAction
 from qgis.core import QgsProject, QgsRasterLayer, QgsMessageLog
 
 from .utils import WMS_SERVERS, WMS_SERVERS_GROUPS, tr, CustomMessageBox
+from .config import Config
 
 
 class OrtoAddingTool(object):
@@ -25,6 +26,9 @@ class OrtoAddingTool(object):
         self.services = []
         self.create_menu()
         self.connect_ortofotomapa_group()
+        if Config().setts['font_changed']:
+            CustomMessageBox.stylesheet += \
+                f'\n* {{font: {QSettings().value("qgis/stylesheet/fontPointSize")}pt}}'
 
     def connect_ortofotomapa_group(self):
         """
@@ -99,7 +103,7 @@ class OrtoAddingTool(object):
                 node_parent.removeChildNode(node_layer)
             else:
                 CustomMessageBox(
-                    None, tr('Can\'t add layer') + name).button_ok()
+                    None, tr('Can\'t add layer ') + name).button_ok()
         else:
             lyr = QgsProject.instance().mapLayersByName(name)[0]
             lyrontree = QgsProject.instance().layerTreeRoot().findLayer(

--- a/QuickPrint.py
+++ b/QuickPrint.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 import tempfile
 from qgis.PyQt import QtWidgets
-from qgis.PyQt.QtCore import QRectF, QDateTime
+from qgis.PyQt.QtCore import QRectF, QDateTime, QSettings
 from qgis.PyQt.QtGui import QColor, QFont
 from qgis.PyQt.QtWidgets import QFileDialog, QApplication
 from qgis._core import QgsLayoutExporter, QgsWkbTypes, QgsLayoutItemMap, \
@@ -18,6 +18,7 @@ from typing import Union
 
 from .utils import tr, CustomMessageBox, normalize_path
 from .wydruk_dialog import WydrukDialog
+from .config import Config
 
 pdf_open_error_msg = '''
     Nie znaleziono programu do otwierania plików PDF. Sprawdź, czy jest\n
@@ -85,6 +86,15 @@ class PrintMapTool:
         self.dialog.paperFormatComboBox.currentIndexChanged.connect(
             self.create_composer)
         self.setup_rubberband()
+        if Config().setts['font_changed']:
+            self.set_font_quickprint(QSettings().value("qgis/stylesheet/fontPointSize"))
+
+    def set_font_quickprint(self, font_size):
+        self.dialog.label_2.setStyleSheet(f'{self.dialog.label_2.styleSheet()} font: {font_size}pt;')
+        self.dialog.frame_4.setStyleSheet(
+            f'{self.dialog.frame_4.styleSheet()} QGroupBox, QCheckBox, QToolButton, '
+            f'QLineEdit, QRadioButton, QComboBox, QSpinBox, QProgressBar {{font: {font_size}pt;}}')
+        self.dialog.calendar.setStyleSheet(f'font: {font_size}pt;')
 
     def setup_rubberband(self) -> None:
         self.rubberband = QgsRubberBand(iface.mapCanvas(), QgsWkbTypes.PolygonGeometry)

--- a/Settings/ui_settings_layout.ui
+++ b/Settings/ui_settings_layout.ui
@@ -415,7 +415,7 @@ p, li { white-space: pre-wrap; }
                 <number>5</number>
                 </property>
                 <property name="maximum">
-                <number>30</number>
+                <number>15</number>
                 </property>
                </widget>
               </item>
@@ -435,6 +435,25 @@ p, li { white-space: pre-wrap; }
                </property>
                <property name="text">
                 <string>Choose font size</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="2">
+              <widget class="QPushButton" name="restart_button">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>200</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="text">
+                <string>Restart font size</string>
                </property>
               </widget>
              </item>

--- a/Settings/ui_settings_layout.ui
+++ b/Settings/ui_settings_layout.ui
@@ -389,6 +389,59 @@ p, li { white-space: pre-wrap; }
            </widget>
           </item>
           <item>
+           <widget class="QGroupBox" name="groupBox_5">
+            <property name="title">
+             <string>Choose font size</string>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_2">
+             <property name="topMargin">
+              <number>20</number>
+             </property>
+              <property name="leftMargin">
+               <number>9</number>
+              </property>
+              <property name="topMargin">
+               <number>20</number>
+              </property>
+              <property name="rightMargin">
+               <number>600</number>
+              </property>
+              <property name="bottomMargin">
+               <number>9</number>
+              </property>
+              <item row="0" column="0">
+               <widget class="QSpinBox" name="spinBox_font">
+                <property name="minimum">
+                <number>5</number>
+                </property>
+                <property name="maximum">
+                <number>30</number>
+                </property>
+               </widget>
+              </item>
+             <item row="0" column="1">
+              <widget class="QPushButton" name="spinBox_button">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>200</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="text">
+                <string>Choose font size</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
            <spacer name="verticalSpacer">
             <property name="orientation">
              <enum>Qt::Vertical</enum>

--- a/giap_dynamic_layout.py
+++ b/giap_dynamic_layout.py
@@ -205,7 +205,6 @@ class MainWidget(QWidget, FORM_CLASS):
                 f"""QFrame, QLabel, QToolTip, QTextEdit{{
             font:{value}pt}}"""
             )
-            # raise
             self.instr.setTextFormat(Qt.AutoText)
             self.instr.setScaledContents(True)
             self.frm = QFrame()
@@ -1153,7 +1152,6 @@ class CustomLabel(QLabel):
         self.setStyleSheet(
             f'font:{value} "Segoe UI"; font-weight: normal; '
         )
-        # raise
         self.cinput = QLineEdit(self)
         self.cinput.setWindowFlags(Qt.Popup)
         self.cinput.editingFinished.connect(self.handleEditingFinished)

--- a/giap_dynamic_layout.py
+++ b/giap_dynamic_layout.py
@@ -4,7 +4,7 @@ from math import ceil
 from plugins.processing.tools.general import execAlgorithmDialog
 from qgis.PyQt import uic, QtWidgets
 from qgis.PyQt.QtCore import Qt, QSize, QEvent, pyqtSignal, QMimeData, QRect, \
-    QTimer, QPoint
+    QTimer, QPoint, QSettings
 from qgis.PyQt.QtGui import QDrag, QPainter, QPixmap, QCursor, QIcon, QFont, \
     QFontMetrics
 from qgis.PyQt.QtWidgets import QWidget, QApplication, QHBoxLayout, \
@@ -199,10 +199,13 @@ class MainWidget(QWidget, FORM_CLASS):
             scrll = QScrollArea(self)
             scrll.setWidgetResizable(True)
             scrll.setWidget(self.instr)
+            value = QSettings().value("qgis/stylesheet/fontPointSize") if \
+                self.conf.setts["font_changed"] else 9
             self.instr.setStyleSheet(
-                """QFrame, QLabel, QToolTip, QTextEdit{
-            font:9pt}"""
+                f"""QFrame, QLabel, QToolTip, QTextEdit{{
+            font:{value}pt}}"""
             )
+            # raise
             self.instr.setTextFormat(Qt.AutoText)
             self.instr.setScaledContents(True)
             self.frm = QFrame()
@@ -1144,9 +1147,13 @@ class CustomLabel(QLabel):
         super(CustomLabel, self).__init__(parent)
         self.setAttribute(Qt.WA_DeleteOnClose)
         self.setText(lab)
+        self.conf = Config()
+        value = QSettings().value("qgis/stylesheet/fontPointSize") if \
+            self.conf.setts["font_changed"] else 10
         self.setStyleSheet(
-            'font: "Segoe UI"; font-weight: normal; '
+            f'font:{value} "Segoe UI"; font-weight: normal; '
         )
+        # raise
         self.cinput = QLineEdit(self)
         self.cinput.setWindowFlags(Qt.Popup)
         self.cinput.editingFinished.connect(self.handleEditingFinished)

--- a/giap_dynamic_layout.py
+++ b/giap_dynamic_layout.py
@@ -1145,7 +1145,7 @@ class CustomLabel(QLabel):
         self.setAttribute(Qt.WA_DeleteOnClose)
         self.setText(lab)
         self.setStyleSheet(
-            'font: 10pt "Segoe UI"; font-weight: normal; '
+            'font: "Segoe UI"; font-weight: normal; '
         )
         self.cinput = QLineEdit(self)
         self.cinput.setWindowFlags(Qt.Popup)

--- a/giap_layout.py
+++ b/giap_layout.py
@@ -22,7 +22,7 @@ from .Searcher.searchTool import SearcherTool
 from .Settings.settings_layout import SettingsDialog
 from .StyleManager.stylemanager import StyleManagerDialog
 from .config import Config
-from .giap_dynamic_layout import MainWidget
+from .giap_dynamic_layout import MainWidget, CustomLabel
 from .kompozycje_widget import kompozycjeWidget
 from .ribbon_config import RIBBON_DEFAULT
 from .tools import StyleManager
@@ -47,10 +47,21 @@ class MainTabQgsWidget:
         self.plugin_dir = os.path.dirname(__file__)
         self.install_translator()
         self.main_widget = MainWidget(self.iface.mainWindow())
+        # self.status_bar = MainWidget(self.iface.statusBarIface())
+        self.tab_bar = MainWidget().tabWidget
         self.kompozycje_widget = kompozycjeWidget()
+        self.custom_label = CustomLabel(tr('New section'))
+        self.settings_pointsize = QSettings().value("qgis/stylesheet/fontPointSize")
+        self.kompozycje_widget.setStyleSheet(f'font: {self.settings_pointsize}pt;')
+        self.main_widget.pokaz_warstwy.setStyleSheet(f'font: {self.settings_pointsize}pt;')
+        self.custom_label.setStyleSheet(f'font: {self.settings_pointsize}pt;')
+        SettingsDialog().font.setPointSize(40)
+            # setstyleSheet(f'{self.settings_pointsize}pt;')
+        # self.tab_bar.setStyleSheet(f'font: {self.settings_pointsize}pt;')
         self.left_docks = []
         self.config = Config()
         self.searcher = SearcherTool(self.main_widget, self.iface)
+        self.settings = QMenu(self.main_widget)
 
         self.style_manager = StyleManager(self)
         self.print_map_tool = PrintMapTool(self.iface)
@@ -459,6 +470,7 @@ class MainTabQgsWidget:
         self.style_manager_dlg.setWindowFlags(
             Qt.Window | Qt.WindowCloseButtonHint
         )
+        # self.style_manager_dlg.setStyleSheet(QSettings().value("qgis/stylesheet/fontPointSize"))
         self.style_manager_dlg.exec_()
 
     def show_settings_dialog(self) -> None:
@@ -474,6 +486,8 @@ class MainTabQgsWidget:
             self.set_dlg.radioButton_en.setChecked(True)
         elif str(QSettings().value('locale/userLocale')) == "pl_PL":
             self.set_dlg.radioButton_pl.setChecked(True)
+        self.set_dlg.spinBox_font.setValue(int(self.settings_pointsize))
+        self.set_dlg.spinBox_button.clicked.connect(self.set_size)
         self.set_dlg.exec_()
 
     def set_polish(self) -> None:
@@ -507,6 +521,37 @@ class MainTabQgsWidget:
             0
         )
         self.restart_qgis()
+
+    def set_size(self):
+        # self.menu_bar = self.iface.mainWindow().menuBar()
+        # self.tab_bar = MainWidget().tabWidget
+        # self.status_bar = self.iface.statusBarIface()
+        # self.layer_tree_view = self.iface.layerTreeView()
+        # self.set_dlg.spinBox_font.setValue(self.set_dlg.spinBox_font.value())
+        value = self.set_dlg.spinBox_font.value()
+        self.set_dlg.spinBox_font.setValue(value)
+        QSettings().setValue('qgis/stylesheet/fontPointSize', value)
+
+        # # self.kompozycje_widget.setStyleSheet(f'font: {value}pt;')  # napis kompoyzje wszystkie warstwy
+        #
+        self.iface.messageBar().pushMessage(
+            'GIAP-PolaMap(lite)',
+            tr('Please, restart QGIS!'),
+            Qgis.Info,
+            0
+        )
+        self.restart_qgis()
+        # self.main_widget.setStyleSheet(f'font: {value}pt;')
+        # # self.settings
+        # # self.menu_bar.setStyleSheet(f' QMenuBar,\
+        # # QMenu {{font: {value}pt;}}')
+        # self.menu_bar.setStyleSheet(f'font: {value}pt;')
+        # self.status_bar.setStyleSheet(f'font: {value}pt;')
+        # self.layer_tree_view.setStyleSheet(f'font: {value}pt;')
+        # custom_label = giap_dynamic_layout.CustomLabel(tr('New section'))
+        # custom_label.setStyleSheet(f'font: {value}pt;')
+        # self.style_manager.run_last_style(value)
+
 
     def restore_default_ribbon_settings(self) -> None:
         self.set_dlg.pushButton_restore.clicked.disconnect()

--- a/i18n/giap_pl.ts
+++ b/i18n/giap_pl.ts
@@ -1255,5 +1255,15 @@ lub uzupełnij wcześniejsze pola i wskaż numer działki np. 17/2</translation>
         <source>Page orientation</source>
         <translation>Orientacja wydruku</translation>
     </message>
+    <message>
+        <location filename="../Settings/ui_settings_layout.ui" line="437"/>
+        <source>Choose font size</source>
+        <translation>Wybierz rozmiar czcionki</translation>
+    </message>
+    <message>
+        <location filename="../Settings/ui_settings_layout.ui" line="456"/>
+        <source>Restart font size</source>
+        <translation>Powrót do ustawień domyślnych czcionki</translation>
+    </message>
 </context>
 </TS>

--- a/wydruk_dialog.ui
+++ b/wydruk_dialog.ui
@@ -267,7 +267,7 @@ border: 1px solid #5689b0;
              <item row="0" column="0">
               <widget class="QLineEdit" name="adnotacje_lineEdit">
                <property name="maxLength">
-                <number>100</number>
+                <number>700</number>
                </property>
               </widget>
              </item>


### PR DESCRIPTION
W oknie dialogowym ustawień dodano sekcję do zmiany rozmiaru czcionek. Zmiany dokonują się w oknie głównym QGISA oraz zakładkach i dialogach GIAP.